### PR TITLE
add bottom_padding option to control end-of-document scroll position

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,10 @@ require("markdown_preview").setup({
   mermaid_renderer = "js",              -- "js" (browser mermaid.js) or "rust" (mmdr CLI, ~400x faster)
 
   scroll_sync = true,                   -- browser follows cursor position
+
+  -- Fraction (0–1): vertical position of the final line when scrolled to end.
+  -- 0.5 = middle of viewport (default), 1.0 = bottom edge (no extra space)
+  bottom_padding = 0.5,
 })
 ```
 

--- a/assets/index.html
+++ b/assets/index.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html lang="en" data-theme="dark">
+<html lang="en" data-theme="dark" data-bottom-padding="__BOTTOM_PADDING__">
 
 <head>
     <meta charset="utf-8" />
@@ -839,6 +839,8 @@
         import mermaid from 'https://cdn.jsdelivr.net/npm/mermaid@11/dist/mermaid.esm.min.mjs';
         import markdownItGithubAlerts from 'https://unpkg.com/markdown-it-github-alerts@1.0.1/dist/index.mjs';
 
+        const BOTTOM_PADDING = parseFloat(document.documentElement.dataset.bottomPadding) || 0.5;
+
         // ── DOM refs ──────────────────────────────────────────────────
         const $ = (id) => document.getElementById(id);
         const contentEl = $('content');
@@ -1176,6 +1178,7 @@
                 } else {
                     contentEl.innerHTML = html;
                 }
+                applyBottomPadding();
 
                 const blocks = contentEl.querySelectorAll('.mermaid-block[data-mermaid-source]:not(.mermaid-rendered)');
                 for (const block of blocks) {
@@ -1405,6 +1408,12 @@
                 scrollToSourceLine(lastScrollData.line, lastScrollData.total || 1);
             }
         }).observe(contentEl);
+
+        // ── Bottom padding ────────────────────────────────────────────
+        function applyBottomPadding() {
+            contentEl.style.paddingBottom = `${(1 - BOTTOM_PADDING) * window.innerHeight}px`;
+        }
+        window.addEventListener('resize', applyBottomPadding);
 
         // ── Boot ──────────────────────────────────────────────────────
         (async function boot() {

--- a/lua/markdown_preview/init.lua
+++ b/lua/markdown_preview/init.lua
@@ -31,10 +31,15 @@ M.config = {
 	mermaid_renderer = "js",
 
 	scroll_sync = true, -- sync browser scroll to cursor position
+
+	-- Fraction (0–1): vertical position of the final line when scrolled to end.
+	-- 0.5 = middle of viewport (default), 1.0 = bottom edge (no extra space)
+	bottom_padding = 0.5,
 }
 
 function M.setup(opts)
 	M.config = vim.tbl_deep_extend("force", M.config, opts or {})
+	M.config.bottom_padding = math.max(0, math.min(1, M.config.bottom_padding))
 	M._mmdr_available = nil -- reset so next check re-probes
 end
 
@@ -83,7 +88,9 @@ local function write_index(dir)
 	if not src then
 		error("Could not locate assets/index.html in runtimepath. Make sure the plugin ships it.")
 	end
-	util.copy_file(src, dst)
+	local content = util.read_text(src)
+	content = content:gsub("__BOTTOM_PADDING__", tostring(M.config.bottom_padding))
+	util.write_text(dst, content)
 	return dst
 end
 
@@ -254,7 +261,7 @@ local function get_content(bufnr)
 		local lines = vim.api.nvim_buf_get_lines(bufnr, 0, -1, false)
 		text = table.concat(lines, "\n")
 	elseif vim.api.nvim_buf_get_name(bufnr):match("%.mmd$")
-		or vim.api.nvim_buf_get_name(bufnr):match("%.mermaid$") then
+        or vim.api.nvim_buf_get_name(bufnr):match("%.mermaid$") then
 		-- .mmd / .mermaid files: treat entire buffer as mermaid
 		local lines = vim.api.nvim_buf_get_lines(bufnr, 0, -1, false)
 		text = "```mermaid\n" .. table.concat(lines, "\n") .. "\n```\n"


### PR DESCRIPTION
Adds a bottom_padding config option (fraction 0–1) that controls how far from the top of the viewport the final line sits when scrolled to the end. Default 0.5 means the last line is scrollable to the vertical midpoint.

The value is injected into index.html at startup via template substitution (__BOTTOM_PADDING__ token), avoiding any SSE race conditions at page load.

It looks like some of the diffs are due to autoformatting. The substantive changes are in `assets/index.html` and in the chunk on line 94 of `lua/markdown_preview/init.lua`.