### PR TITLE
feat: add configurable default theme option

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Live **Markdown preview** for Neovim with first-class **Mermaid diagram** suppor
       instance_mode = "takeover",  -- "takeover" (one tab) or "multi" (tab per instance)
       port = 0,                    -- 0 = auto (8421 for takeover, OS-assigned for multi)
       open_browser = true,
-      theme = "dark",              -- "dark" or "light"; initial preview theme
+      default_theme = "dark",      -- "dark" or "light"; initial preview theme
       debounce_ms = 300,
     })
   end,
@@ -121,7 +121,7 @@ require("markdown_preview").setup({
 
   mermaid_renderer = "js",              -- "js" (browser mermaid.js) or "rust" (mmdr CLI, ~400x faster)
 
-  theme = "dark",                       -- "dark" or "light"; initial preview theme (toggleable in browser)
+  default_theme = "dark",               -- "dark" or "light"; initial preview theme (toggleable in browser)
 
   scroll_sync = true,                   -- browser follows cursor position
 

--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ Live **Markdown preview** for Neovim with first-class **Mermaid diagram** suppor
       instance_mode = "takeover",  -- "takeover" (one tab) or "multi" (tab per instance)
       port = 0,                    -- 0 = auto (8421 for takeover, OS-assigned for multi)
       open_browser = true,
+      theme = "dark",              -- "dark" or "light"; initial preview theme
       debounce_ms = 300,
     })
   end,
@@ -119,6 +120,8 @@ require("markdown_preview").setup({
   notify_on_refresh = false,            -- show notification on refresh
 
   mermaid_renderer = "js",              -- "js" (browser mermaid.js) or "rust" (mmdr CLI, ~400x faster)
+
+  theme = "dark",                       -- "dark" or "light"; initial preview theme (toggleable in browser)
 
   scroll_sync = true,                   -- browser follows cursor position
 

--- a/assets/index.html
+++ b/assets/index.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html lang="en" data-theme="dark" data-bottom-padding="__BOTTOM_PADDING__" data-mermaid-elk="__MERMAID_ELK__" data-live-token="__LIVE_TOKEN__">
+<html lang="en" data-theme="__THEME__" data-bottom-padding="__BOTTOM_PADDING__" data-mermaid-elk="__MERMAID_ELK__" data-live-token="__LIVE_TOKEN__">
 
 <head>
     <meta charset="utf-8" />
@@ -879,7 +879,7 @@
 
         // ── State ─────────────────────────────────────────────────────
         let lastContent = null;
-        let currentTheme = 'dark';
+        let currentTheme = document.documentElement.dataset.theme || 'dark';
         let mermaidIdCounter = 0;
         let sseConnected = false;
         const loadedPacks = new Set();
@@ -1453,7 +1453,7 @@
                     const elkLayouts = await import('https://cdn.jsdelivr.net/npm/@mermaid-js/layout-elk@0.2.1/dist/mermaid-layout-elk.esm.min.mjs');
                     mermaid.registerLayoutLoaders(elkLayouts.default || elkLayouts);
                 }
-                applyTheme('dark');
+                applyTheme(currentTheme);
                 await sync(true);
             } catch (e) {
                 console.error('[markdown-preview] boot error:', e);

--- a/lua/markdown_preview/init.lua
+++ b/lua/markdown_preview/init.lua
@@ -42,6 +42,9 @@ M.config = {
 
 	scroll_sync = true, -- sync browser scroll to cursor position
 
+	-- "dark" or "light"; determines the initial theme of the preview page
+	theme = "dark",
+
 	-- Fraction (0–1): vertical position of the final line when scrolled to end.
 	-- 0.5 = middle of viewport (default), 1.0 = bottom edge (no extra space)
 	bottom_padding = 0.5,
@@ -105,6 +108,7 @@ local function write_index(dir)
 	content = content:gsub("__BOTTOM_PADDING__", function() return tostring(M.config.bottom_padding) end)
 	content = content:gsub("__MERMAID_ELK__", function() return M.config.mermaid_elk and "true" or "false" end)
 	content = content:gsub("__LIVE_TOKEN__", function() return M._token or "" end)
+	content = content:gsub("__THEME__", function() return M.config.theme end)
 	util.write_text(dst, content)
 	return dst
 end

--- a/lua/markdown_preview/init.lua
+++ b/lua/markdown_preview/init.lua
@@ -43,7 +43,7 @@ M.config = {
 	scroll_sync = true, -- sync browser scroll to cursor position
 
 	-- "dark" or "light"; determines the initial theme of the preview page
-	theme = "dark",
+	default_theme = "dark",
 
 	-- Fraction (0–1): vertical position of the final line when scrolled to end.
 	-- 0.5 = middle of viewport (default), 1.0 = bottom edge (no extra space)
@@ -108,7 +108,7 @@ local function write_index(dir)
 	content = content:gsub("__BOTTOM_PADDING__", function() return tostring(M.config.bottom_padding) end)
 	content = content:gsub("__MERMAID_ELK__", function() return M.config.mermaid_elk and "true" or "false" end)
 	content = content:gsub("__LIVE_TOKEN__", function() return M._token or "" end)
-	content = content:gsub("__THEME__", function() return M.config.theme end)
+	content = content:gsub("__THEME__", function() return M.config.default_theme end)
 	util.write_text(dst, content)
 	return dst
 end


### PR DESCRIPTION
## Summary
- Add `theme` config option (`"dark"` or `"light"`) to set the initial preview page theme, defaulting to `"dark"` for backwards compatibility
- Previously the theme was hardcoded to `"dark"` in both the HTML template (`data-theme`) and JavaScript (`currentTheme` / `applyTheme('dark')`)
- Uses the same `__PLACEHOLDER__` + gsub pattern as `bottom_padding`

## Changes
- `assets/index.html`: Replace hardcoded `data-theme="dark"` with `data-theme="__THEME__"`, read initial theme from `dataset.theme` in JS, and use `currentTheme` in boot instead of hardcoded `'dark'`
- `lua/markdown_preview/init.lua`: Add `theme = "dark"` to config, add `__THEME__` gsub in `write_index()`
- `README.md`: Document `theme` option in Quick start and Configuration sections

## Usage
```lua
require("markdown_preview").setup({ theme = "light" })
```