### PR TITLE
YAML front-matter handling, default theme option, and code block UI enhancement

### DIFF
--- a/assets/index.html
+++ b/assets/index.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html lang="en" data-theme="dark" data-bottom-padding="__BOTTOM_PADDING__">
+<html lang="en" data-theme="__DEFAULT_THEME__" data-bottom-padding="__BOTTOM_PADDING__" data-hide-yaml="__HIDE_YAML__">
 
 <head>
     <meta charset="utf-8" />
@@ -631,6 +631,57 @@
             margin-left: .3em;
         }
 
+        /* ── Front-matter YAML panel ──────────────────────────────────── */
+        #fmPanel {
+            max-width: 900px;
+            margin: .8rem auto 0;
+            padding: 0 2rem;
+        }
+
+        #fmPanel summary {
+            cursor: pointer;
+            font-size: .8rem;
+            color: var(--fg-muted);
+            user-select: none;
+            list-style: none;
+            display: flex;
+            align-items: center;
+            gap: .4rem;
+            padding: .3rem 0;
+        }
+
+        #fmPanel summary::-webkit-details-marker { display: none; }
+
+        #fmPanel summary::before {
+            content: '▶';
+            font-size: .65rem;
+            transition: transform .15s;
+            display: inline-block;
+        }
+
+        #fmPanel[open] summary::before {
+            transform: rotate(90deg);
+        }
+
+        #fmPanel pre {
+            margin: .4rem 0 .8rem;
+            background: var(--code-bg);
+            border: 1px solid var(--stroke);
+            border-radius: 8px;
+            padding: .8em 1em;
+            overflow-x: auto;
+            font-size: .82em;
+            font-family: ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas, monospace;
+            color: var(--fg-muted);
+        }
+
+        #fmPanel pre code {
+            background: none;
+            padding: 0;
+            border-radius: 0;
+            font-size: 1em;
+        }
+
         /* ── Mermaid diagrams ──────────────────────────────────────────── */
         .mermaid-block {
             position: relative;
@@ -791,6 +842,12 @@
         </button>
     </header>
 
+    <!-- Front-matter YAML panel (hidden until front-matter is parsed) -->
+    <details id="fmPanel" style="display:none">
+        <summary id="fmSummary">Front matter</summary>
+        <pre id="fmContent"><code></code></pre>
+    </details>
+
     <!-- Loading skeleton (replaced by content) -->
     <div id="loadingSkeleton" class="skeleton">
         <div class="skeleton-line"></div>
@@ -848,6 +905,7 @@
         import markdownItGithubAlerts from 'https://unpkg.com/markdown-it-github-alerts@1.0.1/dist/index.mjs';
 
         const BOTTOM_PADDING = parseFloat(document.documentElement.dataset.bottomPadding) || 0.5;
+        const HIDE_YAML = document.documentElement.dataset.hideYaml === 'true';
 
         // ── DOM refs ──────────────────────────────────────────────────
         const $ = (id) => document.getElementById(id);
@@ -879,7 +937,7 @@
 
         // ── State ─────────────────────────────────────────────────────
         let lastContent = null;
-        let currentTheme = 'dark';
+        let currentTheme = document.documentElement.getAttribute('data-theme') || 'dark';
         let mermaidIdCounter = 0;
         let sseConnected = false;
         const loadedPacks = new Set();
@@ -973,7 +1031,10 @@
         });
 
         // Register plugins
-        if (window.markdownItFrontMatter) md.use(window.markdownItFrontMatter, function() {});
+        let lastFrontMatter = null;
+        if (window.markdownItFrontMatter) {
+            md.use(window.markdownItFrontMatter, function(fm) { lastFrontMatter = fm; });
+        }
         md.use(markdownItGithubAlerts);
         if (window.markdownitEmoji) md.use(window.markdownitEmoji);
         if (window.markdownitFootnote) md.use(window.markdownitFootnote);
@@ -1156,6 +1217,21 @@
                 const html = md.render(text);
 
                 showContent();
+
+                // Update front-matter YAML panel
+                const fmPanel = document.getElementById('fmPanel');
+                const fmContent = document.getElementById('fmContent');
+                if (fmPanel && fmContent) {
+                    if (!HIDE_YAML && lastFrontMatter && lastFrontMatter.trim()) {
+                        const wasOpen = fmPanel.open;
+                        fmContent.querySelector('code').textContent = lastFrontMatter.trim();
+                        fmPanel.style.display = '';
+                        if (wasOpen) fmPanel.open = true;
+                    } else {
+                        fmPanel.style.display = 'none';
+                    }
+                    lastFrontMatter = null;
+                }
 
                 if (window.morphdom) {
                     const wrapper = document.createElement('div');
@@ -1427,7 +1503,7 @@
         // ── Boot ──────────────────────────────────────────────────────
         (async function boot() {
             try {
-                applyTheme('dark');
+                applyTheme(currentTheme);
                 await sync(true);
             } catch (e) {
                 console.error('[markdown-preview] boot error:', e);

--- a/assets/index.html
+++ b/assets/index.html
@@ -896,7 +896,7 @@
     <script src="https://cdn.jsdelivr.net/npm/markdown-it-footnote@4.0.0/dist/markdown-it-footnote.min.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/markdown-it-task-lists@2.1.1/dist/markdown-it-task-lists.min.js"></script>
     <script src="https://unpkg.com/markdown-it-anchor@9.2.0/dist/markdownItAnchor.umd.js"></script>
-    <script src="https://cdn.jsdelivr.net/npm/markdown-it-front-matter@0.2.4/index.min.js"></script>
+
     <script src="https://cdn.jsdelivr.net/npm/katex@0.16.28/dist/katex.min.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/markdown-it-texmath@1.0.0/texmath.js"></script>
 
@@ -1030,11 +1030,52 @@
             }
         });
 
-        // Register plugins
+        // ── Front-matter plugin (inlined; CDN build is CJS-only, no global export) ──
         let lastFrontMatter = null;
-        if (window.markdownItFrontMatter) {
-            md.use(window.markdownItFrontMatter, function(fm) { lastFrontMatter = fm; });
-        }
+        md.use(function frontMatterPlugin(md) {
+            const MARKER = '-', MARKER_CHAR = MARKER.charCodeAt(0);
+            md.block.ruler.before('table', 'front_matter', function(state, startLine, endLine, silent) {
+                // Must be at line 0 and start with '-'
+                if (startLine !== 0 || state.src.charCodeAt(state.bMarks[0] + state.tShift[0]) !== MARKER_CHAR) return false;
+
+                // Count opening dashes
+                let start = state.bMarks[startLine] + state.tShift[startLine];
+                let max = state.eMarks[startLine];
+                let pos = start;
+                while (pos <= max && state.src[pos] === '-') pos++;
+                if (pos - start < 3) return false;
+                if (silent) return true;
+
+                // content starts on next line
+                const startContent = state.bMarks[startLine + 1] + state.tShift[startLine + 1];
+
+                // Find closing ---
+                let nextLine = startLine + 1;
+                let closed = false;
+                while (nextLine < endLine) {
+                    start = state.bMarks[nextLine] + state.tShift[nextLine];
+                    max = state.eMarks[nextLine];
+                    if (state.src[start] === '-') {
+                        let p = start;
+                        while (p <= max && state.src[p] === '-') p++;
+                        if (p - start >= 3) { closed = true; break; }
+                    }
+                    nextLine++;
+                }
+
+                const meta = state.src.slice(startContent, state.bMarks[nextLine] + state.tShift[nextLine] - 1);
+                const token = state.push('front_matter', null, 0);
+                token.hidden = true;
+                token.block = true;
+                token.markup = state.src.slice(state.bMarks[startLine], max);
+                token.meta = meta;
+                token.map = [startLine, nextLine + (closed ? 1 : 0)];
+                state.line = nextLine + (closed ? 1 : 0);
+
+                lastFrontMatter = meta;
+                return true;
+            }, { alt: ['paragraph', 'reference', 'blockquote', 'list'] });
+        });
         md.use(markdownItGithubAlerts);
         if (window.markdownitEmoji) md.use(window.markdownitEmoji);
         if (window.markdownitFootnote) md.use(window.markdownitFootnote);
@@ -1214,6 +1255,7 @@
             lastContent = text;
 
             try {
+                lastFrontMatter = null; // reset before render so missing front-matter hides the panel
                 const html = md.render(text);
 
                 showContent();

--- a/assets/index.html
+++ b/assets/index.html
@@ -454,14 +454,18 @@
         }
 
         /* Code blocks */
-        #content pre {
+        #content .code-wrap {
             position: relative;
+            margin: 0 0 1em;
+        }
+
+        #content pre {
             background: var(--code-bg);
             border: 1px solid var(--stroke);
             border-radius: 8px;
             padding: 1em;
             overflow-x: auto;
-            margin: 0 0 1em;
+            margin: 0;
             scrollbar-width: thin;
             scrollbar-color: var(--scroll-thumb) transparent;
         }
@@ -474,9 +478,8 @@
             line-height: 1.55;
         }
 
-        /* Language badge on code blocks */
-        #content pre[data-lang]::before {
-            content: attr(data-lang);
+        /* Language badge on code blocks (real DOM element inside .code-wrap) */
+        #content .code-wrap .code-lang {
             position: absolute;
             top: 0;
             right: 0;
@@ -491,10 +494,12 @@
             letter-spacing: .5px;
             font-weight: 500;
             line-height: 1.4;
+            pointer-events: none;
+            z-index: 2;
         }
 
         /* ── Copy button on code blocks ──────────────────────────────── */
-        #content pre .copy-btn {
+        #content .code-wrap .copy-btn {
             position: absolute;
             top: 6px;
             right: 6px;
@@ -514,21 +519,21 @@
             z-index: 2;
         }
 
-        #content pre:hover .copy-btn {
+        #content .code-wrap:hover .copy-btn {
             opacity: 1;
         }
 
-        #content pre .copy-btn:hover {
+        #content .code-wrap .copy-btn:hover {
             color: var(--fg);
             background: rgba(127, 127, 127, .15);
         }
 
-        #content pre .copy-btn.copied {
+        #content .code-wrap .copy-btn.copied {
             color: #3fb950;
         }
 
-        /* Shift badge down when copy button is present */
-        #content pre[data-lang] .copy-btn {
+        /* Shift copy button down when lang badge is present */
+        #content .code-wrap:has(.code-lang) .copy-btn {
             top: 26px;
         }
 
@@ -1207,7 +1212,26 @@
         // ── Copy button on code blocks ────────────────────────────────
         function attachCopyButtons() {
             contentEl.querySelectorAll('pre.hljs').forEach(pre => {
-                if (pre.querySelector('.copy-btn')) return;
+                // Already wrapped
+                if (pre.parentElement && pre.parentElement.classList.contains('code-wrap')) return;
+
+                // Wrap pre in a positioning container so badge + button stay
+                // fixed at the top-right even when the code scrolls horizontally
+                const wrap = document.createElement('div');
+                wrap.className = 'code-wrap';
+                pre.parentNode.insertBefore(wrap, pre);
+                wrap.appendChild(pre);
+
+                // Lang badge as a real DOM element (not ::before) so it is
+                // positioned relative to .code-wrap, not the scrollable pre
+                if (pre.dataset.lang) {
+                    const lang = document.createElement('span');
+                    lang.className = 'code-lang';
+                    lang.textContent = pre.dataset.lang;
+                    wrap.appendChild(lang);
+                }
+
+                // Copy button
                 const btn = document.createElement('button');
                 btn.className = 'copy-btn';
                 btn.title = 'Copy code';
@@ -1226,7 +1250,7 @@
                         }, 1500);
                     } catch (_) { }
                 });
-                pre.appendChild(btn);
+                wrap.appendChild(btn);
             });
         }
 

--- a/lua/markdown_preview/init.lua
+++ b/lua/markdown_preview/init.lua
@@ -40,6 +40,12 @@ M.config = {
 	-- Fraction (0–1): vertical position of the final line when scrolled to end.
 	-- 0.5 = middle of viewport (default), 1.0 = bottom edge (no extra space)
 	bottom_padding = 0.5,
+
+	-- "dark" | "light" — initial theme for the browser preview
+	default_theme = "dark",
+
+	-- true = never show the front-matter YAML panel at the top of the preview
+	hide_yaml = false,
 }
 
 function M.setup(opts)
@@ -95,6 +101,8 @@ local function write_index(dir)
 	end
 	local content = util.read_text(src)
 	content = content:gsub("__BOTTOM_PADDING__", tostring(M.config.bottom_padding))
+	content = content:gsub("__DEFAULT_THEME__", M.config.default_theme == "light" and "light" or "dark")
+	content = content:gsub("__HIDE_YAML__", M.config.hide_yaml and "true" or "false")
 	util.write_text(dst, content)
 	return dst
 end


### PR DESCRIPTION

## Summary

I identified some UI related small issues and fixed them with Claude:

Three independent improvements to the browser preview, all confined to `assets/index.html` and `lua/markdown_preview/init.lua`. No server logic was changed.

These have been all tested on Neovim v0.12.2.

## 1. YAML front-matter collapsible panel (`hide_yaml`)

YAML front-matter was previously shown as ordinary contents the preview. It is now displayed as a collapsible `<details>` panel at the top of the page, above the document content, below the "markdown preview" UI banner.

**Behaviour:**
- The panel is collapsed by default. Click the `▶ Front matter` label to expand it and see the raw YAML in a code block.
- If the file has no front-matter, the panel is hidden entirely.
- Open/closed state is preserved across live reloads (editing the file does not collapse the panel).
- Set `hide_yaml = true` in `setup()` to suppress the panel entirely; you will not even see the collapsible panel.

**Configuration:**
```lua
require("markdown_preview").setup({
    hide_yaml = true,  -- default: false
})
```

**Implementation note:** `markdown-it-front-matter` on jsDelivr only ships a CommonJS build with no UMD/global wrapper, so the existing `<script>` CDN tag silently did nothing (`window.markdownItFrontMatter` was always `undefined`). The plugin was replaced with an equivalent block rule inlined directly inside the ES module script.


## 2. Configurable default theme (`default_theme`)

The browser preview previously always opened in dark mode (hardcoded). The initial theme is now configurable.

**Configuration:**
```lua
require("markdown_preview").setup({
    default_theme = "light",  -- "dark" (default) or "light"
})
```

The value is injected into `index.html` at server start via the same placeholder substitution pattern used for `bottom_padding`. The in-browser theme toggle button continues to work regardless of the configured default.

## 3. Sticky lang badge and copy button on wide code blocks

When a code block's content was wider than the viewport and the user scrolled it horizontally, the language badge and copy button scrolled off with the content. They now stay fixed at the top-right corner of the visible block.

**Root cause:** `<pre>` had both `position: relative` and `overflow-x: auto`. Absolutely-positioned children are anchored to the element's scrollable content area, not its visible viewport.

**Fix:** Each `<pre>` is now wrapped in a `<div class="code-wrap">` that carries `position: relative`. The `<pre>` itself retains only `overflow-x: auto`. The badge and copy button are children of the wrapper, so they are always anchored to the visible corner of the block regardless of horizontal scroll position.

The `::before` pseudo-element lang badge (which cannot be independently re-parented) was replaced with a real `<span class="code-lang">` DOM element injected by the existing `attachCopyButtons()` function.

## Files changed

| File | Changes |
|---|---|
| `lua/markdown_preview/init.lua` | Added `default_theme` and `hide_yaml` config keys; two new placeholder substitutions in `write_index` |
| `assets/index.html` | Front-matter panel HTML + CSS + inlined plugin; `__DEFAULT_THEME__` / `__HIDE_YAML__` placeholders; `.code-wrap` wrapper CSS + JS refactor of `attachCopyButtons` |
