### PR TITLE
Add opt-in ELK layout support for mermaid diagrams

### DIFF
--- a/assets/index.html
+++ b/assets/index.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html lang="en" data-theme="dark" data-bottom-padding="__BOTTOM_PADDING__">
+<html lang="en" data-theme="dark" data-bottom-padding="__BOTTOM_PADDING__" data-mermaid-elk="__MERMAID_ELK__">
 
 <head>
     <meta charset="utf-8" />
@@ -1427,6 +1427,10 @@
         // ── Boot ──────────────────────────────────────────────────────
         (async function boot() {
             try {
+                if (document.documentElement.dataset.mermaidElk === 'true') {
+                    const elkLayouts = await import('https://cdn.jsdelivr.net/npm/@mermaid-js/layout-elk@0.2.1/dist/mermaid-layout-elk.esm.min.mjs');
+                    mermaid.registerLayoutLoaders(elkLayouts.default || elkLayouts);
+                }
                 applyTheme('dark');
                 await sync(true);
             } catch (e) {

--- a/lua/markdown_preview/init.lua
+++ b/lua/markdown_preview/init.lua
@@ -35,6 +35,10 @@ M.config = {
 	-- "rust" = pre-render via mermaid-rs-renderer (mmdr) CLI (~400x faster)
 	mermaid_renderer = "js",
 
+	-- Load ELK layout engine for mermaid diagrams (requires internet; adds ~800 KB).
+	-- Enables %%{init: {"layout": "elk"}}%% in diagrams.
+	mermaid_elk = false,
+
 	scroll_sync = true, -- sync browser scroll to cursor position
 
 	-- Fraction (0–1): vertical position of the final line when scrolled to end.
@@ -95,6 +99,7 @@ local function write_index(dir)
 	end
 	local content = util.read_text(src)
 	content = content:gsub("__BOTTOM_PADDING__", tostring(M.config.bottom_padding))
+	content = content:gsub("__MERMAID_ELK__", M.config.mermaid_elk and "true" or "false")
 	util.write_text(dst, content)
 	return dst
 end


### PR DESCRIPTION
## Summary

Adds a `mermaid_elk` config option (default `false`). When enabled, the browser preview loads `@mermaid-js/layout-elk@0.2.1` from jsDelivr and registers it before mermaid initializes, allowing diagrams to use:

```
%%{init: {"layout": "elk"}}%%
```

## Why

ELK produces noticeably cleaner layouts for medium/large flowcharts and class diagrams than mermaid's default dagre layout. It's opt-in because it adds ~800 KB on top of what the preview already fetches from CDN, and most diagrams don't need it.

## Changes

- `lua/markdown_preview/init.lua`: new `mermaid_elk` config (default `false`); substitutes a `__MERMAID_ELK__` placeholder when writing `index.html`, mirroring the existing `__BOTTOM_PADDING__` pattern.
- `assets/index.html`: adds a `data-mermaid-elk` attribute on `<html>`; in `boot()`, conditionally dynamic-imports the ELK layout module and calls `mermaid.registerLayoutLoaders(...)` before the first `sync()`.

## Test plan

- [x] With `mermaid_elk = false` (default), preview behaves exactly as before — no extra network request on boot.
- [x] With `mermaid_elk = true`, a diagram containing `%%{init: {"layout": "elk"}}%%` renders with the ELK layout.
- [ ] If the ELK import fails, the existing boot `try/catch` logs the error and shows an inline error message rather than a blank preview.