### PR TITLE
fix: markdown checkbox rendering typo

### DIFF
--- a/assets/index.html
+++ b/assets/index.html
@@ -999,7 +999,7 @@
         md.use(markdownItGithubAlerts);
         if (window.markdownitEmoji) md.use(window.markdownitEmoji);
         if (window.markdownitFootnote) md.use(window.markdownitFootnote);
-        if (window.markdownItTaskLists) md.use(window.markdownItTaskLists, { enabled: false });
+        if (window.markdownitTaskLists) md.use(window.markdownitTaskLists, { enabled: false });
         if (window.markdownItAnchor) {
             md.use(window.markdownItAnchor, {
                 permalink: false,


### PR DESCRIPTION
This pull request fixes a typo in the initialization of the Markdown preview feature. Specifically, it corrects the case of the `markdownitTaskLists` plugin reference to ensure the task lists plugin is loaded properly.

- Fixed a typo in the plugin name from `window.markdownItTaskLists` to `window.markdownitTaskLists` in `assets/index.html`, ensuring the task lists plugin is correctly initialized.