### PR TITLE
Add option for use over the network (not just loopback)

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,6 +156,24 @@ require("markdown_preview").setup({
 - **`on_start(url)`** — called after the server is ready, before the browser opens. Receives the preview URL as a string.
 - **`on_stop()`** — called after the server is stopped and all cleanup is done.
 
+### Remote access (SSH)
+
+If you're running Neovim on a remote machine over SSH and want to view the preview on your local machine, bind to all interfaces and use `on_start` to print the URL:
+
+```lua
+require("markdown_preview").setup({
+  host = "0.0.0.0",
+  open_browser = false,
+  hooks = {
+    on_start = function(url)
+      vim.notify("Markdown Preview: " .. url, vim.log.levels.INFO)
+    end,
+  },
+})
+```
+
+The notification will show the full URL including the auth token (e.g. `http://10.0.0.5:8421/?t=...`). Most terminals support **Ctrl+Shift+click** on the URL to open it directly in your local browser.
+
 ### Instance modes
 
 **Takeover** (default) — all Neovim instances share a single workspace and browser tab. The first instance to run `:MarkdownPreview` becomes the primary (starts the server on port 8421). Subsequent instances become secondaries — they write content to the shared workspace, and the server's file watcher pushes a reload to the browser. Scroll sync works across instances via HTTP event injection.

--- a/lua/markdown_preview/init.lua
+++ b/lua/markdown_preview/init.lua
@@ -422,11 +422,22 @@ end
 -- Public API
 ---------------------------------------------------------------------------
 
+-- When bound to 0.0.0.0 detect the outbound LAN IP via a UDP connect trick
+-- (no packets are sent; it just lets the kernel pick the right interface).
+local function lan_ip()
+	local udp = vim.loop.new_udp()
+	if not udp then return "127.0.0.1" end
+	local ok = pcall(function() udp:connect("8.8.8.8", 80) end)
+	local addr = ok and udp:getsockname()
+	pcall(function() udp:close() end)
+	return (addr and addr.ip) or "127.0.0.1"
+end
+
 -- Build the URL the browser opens to. Embeds the auth token when one exists
 -- so the first request includes it (the page then stashes it in
 -- sessionStorage for refreshes).
 local function browser_url(port)
-	local display_host = (M.config.host == "0.0.0.0") and "127.0.0.1" or M.config.host
+	local display_host = (M.config.host == "0.0.0.0") and lan_ip() or M.config.host
 	local base = ("http://%s:%d/"):format(display_host, port)
 	if M._token and M._token ~= "" then
 		return base .. "?t=" .. M._token

--- a/lua/markdown_preview/init.lua
+++ b/lua/markdown_preview/init.lua
@@ -8,6 +8,7 @@ local M = {}
 
 M.config = {
 	port = 0, -- 0 = auto; effective port depends on instance_mode
+	host = "127.0.0.1", -- bind address; "0.0.0.0" for network access (e.g. over SSH)
 	open_browser = true,
 
 	-- nil = system default browser. String for app/binary name (e.g. "Firefox",
@@ -425,7 +426,8 @@ end
 -- so the first request includes it (the page then stashes it in
 -- sessionStorage for refreshes).
 local function browser_url(port)
-	local base = ("http://127.0.0.1:%d/"):format(port)
+	local display_host = (M.config.host == "0.0.0.0") and "127.0.0.1" or M.config.host
+	local base = ("http://%s:%d/"):format(display_host, port)
 	if M._token and M._token ~= "" then
 		return base .. "?t=" .. M._token
 	end
@@ -498,6 +500,7 @@ function M.start()
 		local index_path = vim.fs.joinpath(dir, M.config.index_name)
 		local ok, inst = pcall(ls_server.start, {
 			port = port,
+			host = M.config.host,
 			root = dir,
 			default_index = index_path,
 			headers = { ["Cache-Control"] = "no-cache" },


### PR DESCRIPTION
My primary use-case is to SSH into a server (with no GUI) and open the browser on my local machine. The older (but more popular) markdown preview plugin by iamcco which I originally used was able to do this, but I want the best of both worlds here. This PR hence restores this functionality.

Disclaimer: I'm primarily a C++/Python person so I'm not a Lua expert by any means; most of this was generated by AI. But the changes are small and make sense to me. Feel free to poke holes in it.

I'll drop a link to the small change needed in live-server as well.