### PR TITLE
Add print media query for fixing svg images in single page while printing.

### DIFF
--- a/assets/index.html
+++ b/assets/index.html
@@ -766,6 +766,11 @@
                 padding: 1rem 1rem 3rem
             }
         }
+        @media print {
+            .mermaid-block .mermaid-svg-wrap svg {
+                max-height: 95vh !important;
+            }
+        }
     </style>
 </head>
 


### PR DESCRIPTION
Suppose an svg with height greater than page height ( say page height=X, image_height=X+50 ) is included in the document, then, a blank page will get included in the print PDF, followed by size with 50 ( in from the example value ) 

This css avoids that breakage. Images will be fitted into a page with height = 95% of page height.