### PR TITLE
Add setup option for custom markdown filetypes

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,9 @@ require("markdown_preview").setup({
     on_start = nil,   -- fun(url: string)|nil — called after preview starts
     on_stop  = nil,   -- fun()|nil — called after preview stops
   },
+
+	-- Table of filetypes to consider as markdown, e.g. for custom literate markdown files
+	ft = { "markdown" },
 })
 ```
 

--- a/lua/markdown_preview/init.lua
+++ b/lua/markdown_preview/init.lua
@@ -72,7 +72,7 @@ M.config = {
 	},
 
 	-- Table of filetypes to consider as markdown, e.g. for custom literate markdown files
-	ft = { "markdown" }
+	ft = { "markdown" },
 }
 
 function M.setup(opts)

--- a/lua/markdown_preview/init.lua
+++ b/lua/markdown_preview/init.lua
@@ -70,6 +70,9 @@ M.config = {
 		-- fun()|nil — called after preview stops
 		on_stop = nil,
 	},
+
+	-- Table of filetypes to consider as markdown, e.g. for custom literate markdown files
+	ft = { "markdown" }
 }
 
 function M.setup(opts)
@@ -341,7 +344,11 @@ end
 local function get_content(bufnr)
 	local text
 	local ft = vim.bo[bufnr].filetype
-	if ft == "markdown" then
+	local ft_bool_table = {}
+	for _, value in pairs(M.config.ft) do
+		ft_bool_table[value] = true
+	end
+	if ft_bool_table[ft] then
 		local lines = vim.api.nvim_buf_get_lines(bufnr, 0, -1, false)
 		text = table.concat(lines, "\n")
 	elseif vim.api.nvim_buf_get_name(bufnr):match("%.mmd$")


### PR DESCRIPTION
For literate markdown files, or generally any kind of markdown file where users might want to include other filetypes, the filetype reported by vim might not literally be "markdown" but something like e.g. "rzk.markdown" for literate rzk files. To remedy this I introduced a setup option ``ft`` to allow users to specify which filetypes they would like to consider as markdown files. Hopefully this gels well with your intended style for this plugin but please let me know if you have any qualms about this implementation.